### PR TITLE
ensurepip, typos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ MAINTAINER Utsob Roy <uroybd@gmail.com>
 
 ENV PYTHONBUFFERED 1
 
-RUN apk update \
-  && apk --no-cache add python3 \
-     py3-psycopg2 \
+RUN apk add --no-cache \
+        python3 \
+        py3-psycopg2 \
   && python3 -m ensurepip \
   && cd /usr/bin/ \
   && ln -s pydoc3 pydoc \
   && ln -s python3 python \
+  && ln -s pip3 pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,7 @@ ENV PYTHONBUFFERED 1
 RUN apk update \
   && apk --no-cache add python3 \
      py3-psycopg2 \
-     wget \
-  && wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py \
-  && python3 get-pip.py \
+  && python3 -m ensurepip \
   && cd /usr/bin/ \
   && ln -s pydoc3 pydoc \
   && ln -s python3 python \
-  && rm /get-pip.py \
-  && apk del wget \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A python3 alpine image with psycopg2 support for docker. Especially useful for m
 You may want to install pillow here, use `apk update && apk add py3-pillow`.
 
 
-## Versions and resepctive `Docerfile`:
+## Versions and resepctive `Dockerfile`:
 * `3.5` with python 3.5.x and psycopg2 2.6.x ([Dockerfie](https://github.com/uroybd/python3-psycopg2-alpine/blob/3.5/Dockerfile))
 * `3.6`, `latest` with python 3.6.x and psycopg2 2.7.x ([Dockerfie](https://github.com/uroybd/python3-psycopg2-alpine/blob/master/Dockerfile))
 * `3.7`, `edge` with python 3.6.x and psycopg2 2.7.x ([Dockerfie](https://github.com/uroybd/python3-psycopg2-alpine/blob/3.7/Dockerfile))

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A python3 alpine image with psycopg2 support for docker. Especially useful for m
 You may want to install pillow here, use `apk update && apk add py3-pillow`.
 
 
-## Versions and resepctive `Dockerfile`:
-* `3.5` with python 3.5.x and psycopg2 2.6.x ([Dockerfie](https://github.com/uroybd/python3-psycopg2-alpine/blob/3.5/Dockerfile))
-* `3.6`, `latest` with python 3.6.x and psycopg2 2.7.x ([Dockerfie](https://github.com/uroybd/python3-psycopg2-alpine/blob/master/Dockerfile))
-* `3.7`, `edge` with python 3.6.x and psycopg2 2.7.x ([Dockerfie](https://github.com/uroybd/python3-psycopg2-alpine/blob/3.7/Dockerfile))
+## Versions and respective `Dockerfile`:
+* `3.5` with python 3.5.x and psycopg2 2.6.x ([Dockerfile](https://github.com/uroybd/python3-psycopg2-alpine/blob/3.5/Dockerfile))
+* `3.6`, `latest` with python 3.6.x and psycopg2 2.7.x ([Dockerfile](https://github.com/uroybd/python3-psycopg2-alpine/blob/master/Dockerfile))
+* `3.7`, `edge` with python 3.6.x and psycopg2 2.7.x ([Dockerfile](https://github.com/uroybd/python3-psycopg2-alpine/blob/3.7/Dockerfile))
 
 ### Why this Image?
 


### PR DESCRIPTION
I made a version which uses ensurepip (builtin to Python >3.4) instead of downloading an external .py with wget.